### PR TITLE
feat(observability): 新增 Alloy log 收集 pipeline，統一 level 格式並支援 MySQL slow log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ MYSQL_ROOT_PASSWORD=
 REDIS_PASSWORD=
 
 HOST=
+
+VLOGS_PUSH_URL=https://victorialogs.example.com/insert/loki/api/v1/push
+VLOGS_USERNAME=change-me
+VLOGS_PASSWORD=change-me
+LOG_HOSTNAME=local-docker-host

--- a/README.md
+++ b/README.md
@@ -1,0 +1,199 @@
+# Laravel Vue Nginx 開發與 Log 收集說明
+
+此專案使用 `docker compose` 啟動本地開發環境，包含 Laravel、Nuxt、Nginx、MySQL、Redis，以及用來收集 container log 的 `Alloy`。
+
+## 服務說明
+
+- `php`：Laravel 應用程式主服務
+- `reverb`：Laravel Reverb / WebSocket 相關服務
+- `node`：Nuxt 前端開發服務
+- `nginx`：反向代理入口
+- `mysql`：MySQL 資料庫
+- `redis`：Redis 快取
+- `alloy`：收集 Docker container logs，轉送到 Zeabur 上的 VictoriaLogs
+
+## 環境變數
+
+請先設定根目錄的 `.env`：
+
+```env
+MYSQL_DATABASE=stock
+MYSQL_USER=laravel
+MYSQL_PASSWORD=123456
+MYSQL_ROOT_PASSWORD=654321
+
+REDIS_PASSWORD=rreeddiiss
+
+HOST=stock.local
+
+VLOGS_PUSH_URL=https://<你的-victorialogs-公開網域>/insert/loki/api/v1/push
+VLOGS_USERNAME=<basic-auth-帳號>
+VLOGS_PASSWORD=<basic-auth-密碼>
+LOG_HOSTNAME=<這台 Docker 主機的識別名稱>
+```
+
+說明：
+
+- `VLOGS_PUSH_URL` 必須指向 Zeabur 官方模板建立的 `VictoriaLogs` 公開網域
+- `VLOGS_USERNAME`、`VLOGS_PASSWORD` 要和 VictoriaLogs 對外保護設定一致
+- `LOG_HOSTNAME` 只是 log label，用來區分來源主機，例如 `macbook-dev`、`home-server-1`
+
+## 啟動方式
+
+啟動全部服務：
+
+```bash
+docker compose up -d
+```
+
+依服務啟動：
+
+```bash
+docker compose up -d php
+docker compose up -d reverb
+docker compose up -d node
+docker compose up -d nginx
+docker compose up -d mysql
+docker compose up -d redis
+docker compose up -d alloy
+```
+
+查看個別服務 log：
+
+```bash
+docker compose logs -f php
+docker compose logs -f reverb
+docker compose logs -f node
+docker compose logs -f nginx
+docker compose logs -f mysql
+docker compose logs -f redis
+docker compose logs -f alloy
+```
+
+停止個別服務：
+
+```bash
+docker compose stop php
+docker compose stop reverb
+docker compose stop node
+docker compose stop nginx
+docker compose stop mysql
+docker compose stop redis
+docker compose stop alloy
+```
+
+## Alloy Log 收集
+
+`docker-compose.yml` 內的 `alloy` 服務會：
+
+- 從 `/var/run/docker.sock` 讀取所有 container 的 `stdout/stderr`
+- 從 `mysql-slowlog` volume 讀取 MySQL slow query log 檔案
+- 自動加上 `job`、`host`、`compose_project`、`service`、`container`、`image` 等 label
+- 將 log 傳送到 `VLOGS_PUSH_URL`
+- 排除 `alloy` 自己的 container log
+
+### Log Level 統一格式
+
+所有服務的 `level` label 統一輸出為 Title Case：
+
+| Level | 對應服務 |
+|-------|----------|
+| `Debug` | nginx, laravel, node |
+| `Info` | nginx, laravel, node |
+| `Notice` | nginx |
+| `Warning` | nginx, laravel, node, traefik, mysql, mysql slow query |
+| `Error` | nginx, laravel, node, traefik, mysql |
+| `Critical` | nginx, laravel |
+| `Alert` | nginx, laravel, mysql |
+| `Emergency` | nginx, laravel |
+| `Fatal` | node, traefik |
+| `Trace` | traefik |
+| `Note` | mysql |
+| `System` | mysql |
+
+### 各服務保留等級
+
+| 服務 | 保留等級 |
+|------|----------|
+| `nginx` access log | Error 以上（4xx / 5xx） |
+| `nginx` error log | Warning 以上 |
+| `php` / `reverb` | Info 以上（Debug 丟棄） |
+| `node` | 全部保留（有 level 的行） |
+| `traefik` | Warning 以上 |
+| `mysql` | Warning 以上（Note、System 也保留） |
+| `mysql` slow query | 全部保留（超過 `long_query_time` 才會寫入） |
+| 其他服務 | Warning 以上 |
+
+### MySQL Slow Query Log
+
+`my.cnf` 設定：
+
+- `long_query_time = 1`：執行超過 1 秒的查詢才記錄
+- slow log 寫到容器內的 `/var/log/mysql/slow.log`，透過 `mysql-slowlog` named volume 讓 Alloy 直接讀取
+
+每筆 slow query 記錄為多行，Alloy 以 `# Time:` 作為分隔合併後一起送出。在 VictoriaLogs 查詢時使用：
+
+```text
+{service="mysql", log_type="slow_query"}
+```
+
+### 為什麼需要 `alloy-data:/var/lib/alloy/data`
+
+這個 volume 用來保存 Alloy 的本地狀態，不是拿來長期保存應用程式 log。
+
+它的用途是：
+
+- 記住 Docker logs 已經讀到哪裡（包含 slow log 檔案的讀取位置）
+- 避免 Alloy 重啟或 container 重建後，重新讀取與重送大量舊 log
+- 在短暫中斷後，讓 collector 可以延續既有 checkpoint
+
+真正的 log 儲存位置仍然是在 Zeabur 上的 `VictoriaLogs`。
+
+## Zeabur VictoriaLogs 對接
+
+若使用 Zeabur 官方模板建立 `VictoriaLogs`，請確認：
+
+- 該服務已綁定公開網域
+- 本機 `.env` 的 `VLOGS_PUSH_URL` 使用：
+
+```env
+VLOGS_PUSH_URL=https://<公開網域>/insert/loki/api/v1/push
+```
+
+注意：
+
+- 不要自行加上 `:9428` 對外連線
+- `9428` 是服務內部 port，Zeabur 對外通常走公開網域的 HTTPS 入口
+
+## 驗證方式
+
+確認 `alloy` 正常啟動：
+
+```bash
+docker compose up -d alloy
+docker compose logs -f alloy
+```
+
+確認本機某個服務有輸出 warning：
+
+```bash
+docker compose logs --tail=20 php
+```
+
+直接查詢 VictoriaLogs：
+
+```bash
+curl -sk -u "<帳號>:<密碼>" \
+  "https://<公開網域>/select/logsql/query" \
+  --data-urlencode 'query=service:"php"' \
+  --data-urlencode 'limit=10'
+```
+
+也可以用 Grafana Explore 查詢：
+
+```text
+service:"php"
+service:"node"
+service:"mysql" AND log_type:"slow_query"
+compose_project:"laravel-vue-nginx"
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - redis
     networks:
       - internal-network
-      - stock-network # external network
+      # - stock-network # external network
   emails-worker:
     build:
       context: ./php
@@ -209,13 +209,35 @@ services:
     volumes:
       - ./mysql:/var/lib/mysql
       - ./my.cnf:/etc/mysql/conf.d/my.cnf
+      - mysql-slowlog:/var/log/mysql
     networks:
       - internal-network
 
+  alloy:
+    image: grafana/alloy:latest
+    restart: always
+    user: "0:0"
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+      - --server.http.listen-addr=0.0.0.0:12345
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./observability/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - alloy-data:/var/lib/alloy/data
+      - mysql-slowlog:/var/log/mysql:ro
+    environment:
+      VLOGS_PUSH_URL: ${VLOGS_PUSH_URL:-https://victorialogs.example.com/insert/loki/api/v1/push}
+      VLOGS_USERNAME: ${VLOGS_USERNAME:-change-me}
+      VLOGS_PASSWORD: ${VLOGS_PASSWORD:-change-me}
+      LOG_HOSTNAME: ${LOG_HOSTNAME:-local-docker-host}
 networks:
   internal-network:
     driver: bridge
-  stock-network:
-    external: true
   traefik-network:
     external: true
+
+volumes:
+  alloy-data:
+  mysql-slowlog:

--- a/my.cnf
+++ b/my.cnf
@@ -1,3 +1,7 @@
 [mysqld]
 disable_log_bin
 binlog_expire_logs_seconds=3600
+
+slow_query_log      = 1
+slow_query_log_file = /var/log/mysql/slow.log
+long_query_time     = 1

--- a/nginx/conf.d/site.conf
+++ b/nginx/conf.d/site.conf
@@ -1,3 +1,20 @@
+# JSON access log format with request timing.
+# Defined at http-context level (conf.d files are included inside the http {} block).
+log_format json_main escape=json
+  '{'
+    '"time_local":"$time_local",'
+    '"remote_addr":"$remote_addr",'
+    '"method":"$request_method",'
+    '"uri":"$uri",'
+    '"args":"$args",'
+    '"status":$status,'
+    '"bytes_sent":$body_bytes_sent,'
+    '"request_time":$request_time,'
+    '"upstream_response_time":"$upstream_response_time",'
+    '"http_referer":"$http_referer",'
+    '"http_user_agent":"$http_user_agent"'
+  '}';
+
 server {
     listen 80;
     # listen 443 ssl;
@@ -6,7 +23,7 @@ server {
 
     index index.php index.html;
 
-    access_log /dev/stdout;
+    access_log /dev/stdout json_main;
     error_log /dev/stderr;
 
     root /var/www/public;

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -1,0 +1,344 @@
+// ============================================================
+// SECTION 1: Docker Container Discovery
+// ============================================================
+
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+// Turn Docker metadata into stable labels for querying in VictoriaLogs.
+discovery.relabel "containers" {
+  targets = discovery.docker.containers.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    replacement   = "$1"
+    target_label  = "container"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+    target_label  = "compose_project"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
+    target_label  = "service"
+  }
+
+  // Don't ingest Alloy's own logs.
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
+    regex         = "alloy"
+    action        = "drop"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_image"]
+    target_label  = "image"
+  }
+}
+
+// ============================================================
+// SECTION 2: Docker Log Source
+// ============================================================
+
+loki.source.docker "containers" {
+  host    = "unix:///var/run/docker.sock"
+  targets = discovery.relabel.containers.output
+  labels = {
+    job  = "docker",
+    host = sys.env("LOG_HOSTNAME"),
+  }
+  forward_to = [loki.process.docker.receiver]
+}
+
+// ============================================================
+// SECTION 3: Main Processing Pipeline
+// ============================================================
+
+loki.process "docker" {
+  // Unwrap Docker log envelope (sets timestamp + log line).
+  stage.docker {}
+
+  // ----------------------------------------------------------
+  // NGINX ACCESS LOG (JSON, stdout) — lines starting with "{"
+  //
+  // Format set by log_format json_main in nginx/conf.d/site.conf.
+  // Parses request timing, generates Prometheus metrics, keeps
+  // only 4xx/5xx entries in VictoriaLogs.
+  // ----------------------------------------------------------
+  stage.match {
+    selector = `{service="nginx"} |~ "^\\{"`
+
+    stage.json {
+      expressions = {
+        method                 = "method",
+        uri                    = "uri",
+        status                 = "status",
+        request_time           = "request_time",
+        upstream_response_time = "upstream_response_time",
+        remote_addr            = "remote_addr",
+      }
+    }
+
+    stage.labels {
+      values = {
+        method      = "method",
+        status      = "status",
+        remote_addr = "remote_addr",
+      }
+    }
+
+    // Prometheus metrics exposed at Alloy's :12345/metrics endpoint.
+    // Scrape with Prometheus / VictoriaMetrics to build dashboards.
+    stage.metrics {
+      metric.histogram {
+        name        = "nginx_request_duration_seconds"
+        description = "HTTP request duration in seconds"
+        source      = "request_time"
+        buckets     = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+      }
+      metric.counter {
+        name        = "nginx_http_requests_total"
+        description = "Total HTTP requests by method and status"
+        match_all   = true
+        action      = "inc"
+      }
+    }
+
+    // Mark 4xx/5xx with level=error so Grafana colour-codes them.
+    stage.match {
+      selector = `{service="nginx", status=~"[45][0-9][0-9]"}`
+      stage.static_labels {
+        values = { level = "Error" }
+      }
+    }
+
+    // Drop 2xx/3xx — not useful for log search.
+    stage.match {
+      selector            = `{service="nginx", status!~"[45][0-9][0-9]"}`
+      action              = "drop"
+      drop_counter_reason = "nginx_non_error_status"
+    }
+  }
+
+  // ----------------------------------------------------------
+  // NGINX ERROR LOG (text, stderr) — lines NOT starting with "{"
+  //
+  // Format: 2026/03/22 04:12:31 [error] 1#1: message
+  // Levels: debug < info < notice < warn < error < crit < alert < emerg
+  // ----------------------------------------------------------
+  stage.match {
+    selector = `{service="nginx"} !~ "^\\{"`
+
+    stage.decolorize {}
+
+    stage.regex {
+      expression = `\[(?P<level_raw>debug|info|notice|warn|error|crit|alert|emerg)\]`
+    }
+
+    stage.template {
+      source   = "level"
+      template = `{{ if eq .level_raw "emerg" }}Emergency{{ else if eq .level_raw "alert" }}Alert{{ else if eq .level_raw "crit" }}Critical{{ else if eq .level_raw "error" }}Error{{ else if eq .level_raw "warn" }}Warning{{ else if eq .level_raw "notice" }}Notice{{ else if eq .level_raw "info" }}Info{{ else if eq .level_raw "debug" }}Debug{{ else }}{{ .level_raw }}{{ end }}`
+    }
+
+    stage.labels {
+      values = { level = "level" }
+    }
+
+    // Drop debug and info — not actionable.
+    stage.match {
+      selector            = `{service="nginx"} !~ "\\[(warn|error|crit|alert|emerg)\\]"`
+      action              = "drop"
+      drop_counter_reason = "nginx_error_log_below_warn"
+    }
+  }
+
+  // ----------------------------------------------------------
+  // LARAVEL (php / reverb containers): error logs + runner INFO
+  //
+  // Laravel stderr channel outputs to Docker logs.
+  // Format: [YYYY-MM-DD HH:MM:SS] env.LEVEL: message
+  // ----------------------------------------------------------
+  stage.match {
+    selector = `{service=~"php|reverb"}`
+
+    stage.regex {
+      expression = `\] \w+\.(?P<level_raw>DEBUG|INFO|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY):`
+    }
+
+    stage.template {
+      source   = "level"
+      template = `{{ if eq .level_raw "EMERGENCY" }}Emergency{{ else if eq .level_raw "ALERT" }}Alert{{ else if eq .level_raw "CRITICAL" }}Critical{{ else if eq .level_raw "ERROR" }}Error{{ else if eq .level_raw "WARNING" }}Warning{{ else if eq .level_raw "INFO" }}Info{{ else if eq .level_raw "DEBUG" }}Debug{{ else }}{{ .level_raw }}{{ end }}`
+    }
+
+    stage.labels {
+      values = { level = "level" }
+    }
+
+    // Drop Debug — too noisy, not actionable.
+    stage.match {
+      selector            = `{service=~"php|reverb", level="Debug"}`
+      action              = "drop"
+      drop_counter_reason = "laravel_debug_filtered"
+    }
+
+    // Drop lines with no recognised Laravel log level (framework/boot noise).
+    stage.match {
+      selector            = `{service=~"php|reverb"} !~ "\\] \\w+\\.(DEBUG|INFO|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY):"`
+      action              = "drop"
+      drop_counter_reason = "laravel_no_level"
+    }
+  }
+
+  // ----------------------------------------------------------
+  // NODE (Nuxt): strip ANSI colour codes, extract level
+  //
+  // Nuxt emits styled terminal output, e.g.:
+  //   [41m[30m ERROR [39m[49m connect ECONNREFUSED 127.0.0.1:443
+  // After decolorize: ERROR connect ECONNREFUSED …
+  // ----------------------------------------------------------
+  stage.match {
+    selector = `{service="node"}`
+
+    stage.decolorize {}
+
+    // Match Nuxt/Node level keyword at the start of the line (may have leading spaces).
+    stage.regex {
+      expression = `(?i)^\s*(?P<level_raw>ERROR|WARN|INFO|DEBUG|FATAL)\b`
+    }
+
+    stage.template {
+      source   = "level"
+      template = `{{ $l := .level_raw | lower }}{{ if eq $l "error" }}Error{{ else if eq $l "warn" }}Warning{{ else if eq $l "info" }}Info{{ else if eq $l "debug" }}Debug{{ else if eq $l "fatal" }}Fatal{{ else }}{{ .level_raw }}{{ end }}`
+    }
+
+    stage.labels {
+      values = { level = "level" }
+    }
+  }
+
+  // ----------------------------------------------------------
+  // TRAEFIK: strip ANSI codes, normalise 3-letter level abbreviations
+  //
+  // Log format (after decolorize):
+  //   2026-03-22T04:12:31Z WRN Failed to inspect container …
+  // Abbreviated levels: TRC DBG INF WRN ERR FTL
+  // ----------------------------------------------------------
+  stage.match {
+    selector = `{service="traefik"}`
+
+    stage.decolorize {}
+
+    // Capture 3-letter level token between ISO timestamp and message.
+    stage.regex {
+      expression = `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z (?P<level_raw>TRC|DBG|INF|WRN|ERR|FTL) `
+    }
+
+    // Map abbreviated levels to standard names Grafana recognises.
+    stage.template {
+      source   = "level"
+      template = `{{ if eq .level_raw "WRN" }}Warning{{ else if eq .level_raw "ERR" }}Error{{ else if eq .level_raw "INF" }}Info{{ else if eq .level_raw "DBG" }}Debug{{ else if eq .level_raw "TRC" }}Trace{{ else if eq .level_raw "FTL" }}Fatal{{ else }}{{ .level_raw }}{{ end }}`
+    }
+
+    stage.labels {
+      values = { level = "level" }
+    }
+
+    // Drop trace, debug, info — only warn and above for Traefik.
+    stage.match {
+      selector            = `{service="traefik", level=~"Trace|Debug|Info"}`
+      action              = "drop"
+      drop_counter_reason = "traefik_below_warn"
+    }
+  }
+
+  // ----------------------------------------------------------
+  // MYSQL: extract level from bracketed token
+  //
+  // Format: 2026-03-22T05:20:57Z 0 [Warning] [MY-010068] [Server] msg
+  // Levels (already Title Case): Note, Warning, Error, System
+  // ----------------------------------------------------------
+  stage.match {
+    selector = `{service="mysql"}`
+
+    stage.regex {
+      expression = `\[(?P<level>Note|Warning|Error|System)\]`
+    }
+
+    stage.labels {
+      values = { level = "level" }
+    }
+  }
+
+  // ----------------------------------------------------------
+  // ALL OTHER services (redis, …):
+  // keep only warning-and-above messages.
+  // nginx, php, reverb, node, traefik, mysql already handled above.
+  // ----------------------------------------------------------
+  stage.match {
+    selector            = `{service!~"nginx|php|reverb|node|traefik|mysql"} !~ "(?i)\\b(warn|warning|error|fatal|panic|critical|alert|emerg|emergency)\\b"`
+    action              = "drop"
+    drop_counter_reason = "non_warning_or_higher"
+  }
+
+  forward_to = [loki.write.victorialogs.receiver]
+}
+
+// ============================================================
+// SECTION 4: MySQL Slow Query Log (file source)
+//
+// Slow log is a multi-line format; each entry starts with "# Time:".
+// Read directly from the shared volume — not via Docker logs.
+//
+// Entry example:
+//   # Time: 2026-03-22T05:20:57.231509Z
+//   # User@Host: laravel[laravel] @ [172.20.0.5]  Id: 123
+//   # Query_time: 2.345678  Lock_time: 0.000123 Rows_sent: 100  Rows_examined: 1000000
+//   SET timestamp=1711077657;
+//   SELECT * FROM stocks WHERE ...;
+// ============================================================
+
+loki.source.file "mysql_slowlog" {
+  targets = [{
+    __path__ = "/var/log/mysql/slow.log",
+    job      = "mysql_slowlog",
+    host     = sys.env("LOG_HOSTNAME"),
+    service  = "mysql",
+  }]
+  forward_to = [loki.process.mysql_slowlog.receiver]
+}
+
+loki.process "mysql_slowlog" {
+  // Merge lines belonging to the same slow query entry.
+  stage.multiline {
+    firstline     = `^# Time:`
+    max_wait_time = "3s"
+  }
+
+  stage.static_labels {
+    values = {
+      log_type = "slow_query",
+      level    = "Warning",
+    }
+  }
+
+  forward_to = [loki.write.victorialogs.receiver]
+}
+
+// ============================================================
+// SECTION 5: VictoriaLogs Output
+// ============================================================
+
+loki.write "victorialogs" {
+  endpoint {
+    url = sys.env("VLOGS_PUSH_URL")
+
+    basic_auth {
+      username = sys.env("VLOGS_USERNAME")
+      password = sys.env("VLOGS_PASSWORD")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- 新增 `observability/alloy/config.alloy`，建立完整的 Docker log 收集 pipeline，將各服務 log 送到 VictoriaLogs
- 所有服務的 `level` label 統一正規化為 Title Case（`Error`、`Warning`、`Info` 等）
- 新增 MySQL slow query log 收集，透過 named volume 讓 Alloy 直接讀取檔案並以 multiline 合併多行記錄

## 變更內容

### Alloy Pipeline（`observability/alloy/config.alloy`）

| 服務 | 處理方式 | 保留等級 |
|------|----------|----------|
| nginx access log | JSON 解析 + Prometheus metrics | Error（4xx/5xx）|
| nginx error log | regex 提取 level | Warning 以上 |
| php / reverb | regex 提取 level | Info 以上（丟棄 Debug）|
| node (Nuxt) | 脫色 + regex 提取 level | 有 level 的行 |
| traefik | 脫色 + 3 字母縮寫轉換 | Warning 以上 |
| mysql error log | regex 提取 level | 全部保留 |
| mysql slow log | `loki.source.file` + multiline | 全部保留 |

### 其他檔案

- **`nginx/conf.d/site.conf`**：access log 改為 JSON 格式（`log_format json_main`）
- **`docker-compose.yml`**：新增 `alloy` 服務、`mysql-slowlog` named volume（mysql 與 alloy 共用）
- **`my.cnf`**：開啟 `slow_query_log`，`long_query_time = 1`
- **`.env.example`**：補充 `VLOGS_PUSH_URL`、`VLOGS_USERNAME`、`VLOGS_PASSWORD`、`LOG_HOSTNAME`
- **`README.md`**：新增完整的 log 收集架構說明、level 對照表、查詢範例

## Test plan

- [ ] `docker compose up -d` 確認所有服務正常啟動
- [ ] `docker compose logs -f alloy` 確認無錯誤
- [ ] 瀏覽器訪問 API，確認 nginx 4xx/5xx 出現在 VictoriaLogs（`{service="mysql", level="Error"}`）
- [ ] 觸發 Laravel warning log，確認出現在 VictoriaLogs（`{service="php", level="Warning"}`）
- [ ] 執行慢查詢，確認 slow log 出現在 VictoriaLogs（`{service="mysql", log_type="slow_query"}`）
- [ ] 確認所有 level label 均為 Title Case

🤖 Generated with [Claude Code](https://claude.com/claude-code)