### PR TITLE
feat(observability): 新增 Alloy log 收集與 nginx route 正規化

### DIFF
--- a/nginx/conf.d/site.conf
+++ b/nginx/conf.d/site.conf
@@ -1,3 +1,53 @@
+# Route label normalization — generated from `php artisan route:list`.
+# Uses \d+ for numeric model keys (safe: avoids matching static sub-paths like /create).
+# Uses [^/]+ for non-numeric params (version, stock code, token, hash).
+map $uri $route_label {
+    default  $uri;
+
+    # api/cart/{cart}
+    ~^/api/cart/\d+$                                 /api/cart/:id;
+
+    # api/industry/{industry}
+    ~^/api/industry/\d+$                             /api/industry/:id;
+
+    # api/order/{order}  /  api/order/{order}/edit
+    ~^/api/order/\d+/edit$                           /api/order/:id/edit;
+    ~^/api/order/\d+$                                /api/order/:id;
+
+    # api/product/{product}
+    ~^/api/product/\d+$                              /api/product/:id;
+
+    # api/role/{id}
+    ~^/api/role/\d+$                                 /api/role/:id;
+
+    # api/simulation/detail/{id}
+    ~^/api/simulation/detail/\d+$                    /api/simulation/detail/:id;
+
+    # api/simulation/result/daily-report/{id}
+    ~^/api/simulation/result/daily-report/\d+$       /api/simulation/result/daily-report/:id;
+
+    # api/simulation/result/{id|version}  (PUT/DELETE by id, POST/GET by version e.g. v1)
+    ~^/api/simulation/result/[^/]+$                  /api/simulation/result/:param;
+
+    # api/stock/dividend/{code}  api/stock/price/{code}  (stock code may be non-numeric)
+    ~^/api/stock/dividend/[^/]+$                     /api/stock/dividend/:code;
+    ~^/api/stock/price/[^/]+$                        /api/stock/price/:code;
+
+    # api/user/favorite/{favorite}  /  api/user/favorite/{favorite}/edit
+    ~^/api/user/favorite/\d+/edit$                   /api/user/favorite/:id/edit;
+    ~^/api/user/favorite/\d+$                        /api/user/favorite/:id;
+
+    # api/user/tracked-position/{id}/close  /  api/user/tracked-position/{tracked_position}
+    ~^/api/user/tracked-position/\d+/close$          /api/user/tracked-position/:id/close;
+    ~^/api/user/tracked-position/\d+$                /api/user/tracked-position/:id;
+
+    # email/verify/{id}/{hash}
+    ~^/email/verify/\d+/[^/]+$                       /email/verify/:id/:hash;
+
+    # reset-password/{token}
+    ~^/reset-password/[^/]+$                         /reset-password/:token;
+}
+
 # JSON access log format with request timing.
 # Defined at http-context level (conf.d files are included inside the http {} block).
 log_format json_main escape=json
@@ -6,6 +56,7 @@ log_format json_main escape=json
     '"remote_addr":"$remote_addr",'
     '"method":"$request_method",'
     '"uri":"$uri",'
+    '"route":"$route_label",'
     '"args":"$args",'
     '"status":$status,'
     '"bytes_sent":$body_bytes_sent,'
@@ -20,6 +71,13 @@ server {
     # listen 443 ssl;
 
     server_name _;
+
+    # Traefik forwards the real client IP in X-Forwarded-For.
+    # Trust all Docker internal networks (172.x.x.x) as trusted proxies so
+    # nginx replaces $remote_addr with the actual client IP.
+    set_real_ip_from  172.0.0.0/8;
+    real_ip_header    X-Forwarded-For;
+    real_ip_recursive on;
 
     index index.php index.html;
 

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -282,8 +282,8 @@ loki.process "docker" {
 
     stage.metrics {
       metric.histogram {
-        name        = "wordpress_request_duration_seconds"
-        description = "WordPress HTTP request duration in seconds (from bytes_sent proxy)"
+        name        = "wordpress_response_size_bytes"
+        description = "WordPress HTTP response size in bytes"
         source      = "bytes_sent"
         buckets     = [256, 512, 1024, 4096, 16384, 65536, 262144, 1048576]
       }
@@ -348,7 +348,7 @@ loki.process "docker" {
     // Default to "Info" when no bracketed level token is found.
     stage.template {
       source   = "level"
-      template = `{{ if eq .level "" }}System{{ else }}{{ .level }}{{ end }}`
+      template = `{{ if .level }}{{ .level }}{{ else }}System{{ end }}`
     }
 
     stage.labels {

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -76,6 +76,7 @@ loki.process "docker" {
       expressions = {
         method                 = "method",
         uri                    = "uri",
+        route                  = "route",
         status                 = "status",
         request_time           = "request_time",
         upstream_response_time = "upstream_response_time",
@@ -89,6 +90,7 @@ loki.process "docker" {
       values = {
         method      = "method",
         status      = "status",
+        route       = "route",
         remote_addr = "remote_addr",
       }
     }
@@ -102,7 +104,7 @@ loki.process "docker" {
     // set, so the output is still the human-readable string sent to VictoriaLogs.
     stage.template {
       source   = "_msg"
-      template = `{{ .method }} {{ .uri }} {{ .status }} {{ .request_time }}s`
+      template = `{{ .method }} - {{ .route }} - {{ .status }} - {{ .request_time }}s`
     }
 
     // Prometheus metrics exposed at Alloy's :12345/metrics endpoint.
@@ -122,16 +124,16 @@ loki.process "docker" {
       }
     }
 
-    // 4xx = client intent (auth challenge, redirect, not found) — still Info.
-    // Only 5xx server errors are Warning.
+    // 4xx = client intent (auth challenge, redirect, not found) — still info.
+    // Only 5xx server errors are warning.
     stage.static_labels {
-      values = { level = "Info" }
+      values = { level = "info" }
     }
 
     stage.match {
       selector = `{service="nginx", status=~"5[0-9][0-9]"}`
       stage.static_labels {
-        values = { level = "Warning" }
+        values = { level = "warning" }
       }
     }
   }
@@ -158,10 +160,11 @@ loki.process "docker" {
       expression = `" (?P<http_status>5\d\d)(?: |$)`
     }
 
-    // Priority: nginx error level > HTTP 5xx > Info (default).
+    // Priority: nginx error level > HTTP 5xx > info (default).
+    // emerg/alert/crit all map to critical; notice maps to info.
     stage.template {
       source   = "level"
-      template = `{{ if eq .level_raw "emerg" }}Emergency{{ else if eq .level_raw "alert" }}Alert{{ else if eq .level_raw "crit" }}Critical{{ else if eq .level_raw "error" }}Error{{ else if eq .level_raw "warn" }}Warning{{ else if eq .level_raw "notice" }}Notice{{ else if eq .level_raw "info" }}Info{{ else if eq .level_raw "debug" }}Debug{{ else if .http_status }}Warning{{ else }}Info{{ end }}`
+      template = `{{ if eq .level_raw "emerg" }}critical{{ else if eq .level_raw "alert" }}critical{{ else if eq .level_raw "crit" }}critical{{ else if eq .level_raw "error" }}error{{ else if eq .level_raw "warn" }}warning{{ else if eq .level_raw "notice" }}info{{ else if eq .level_raw "info" }}info{{ else if eq .level_raw "debug" }}debug{{ else if .http_status }}warning{{ else }}info{{ end }}`
     }
 
     stage.labels {
@@ -187,14 +190,14 @@ loki.process "docker" {
       expression = `\] \w+\.(?P<level_raw>DEBUG|INFO|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY):`
     }
 
-    // Format 2: PHP access log — only flag 5xx as Warning; 4xx and below → Info.
+    // Format 2: PHP access log — only flag 5xx as warning; 4xx and below → info.
     stage.regex {
       expression = `" (?P<http_status>5\d\d)$`
     }
 
     stage.template {
       source   = "level"
-      template = `{{ if eq .level_raw "EMERGENCY" }}Emergency{{ else if eq .level_raw "ALERT" }}Alert{{ else if eq .level_raw "CRITICAL" }}Critical{{ else if eq .level_raw "ERROR" }}Error{{ else if eq .level_raw "WARNING" }}Warning{{ else if eq .level_raw "INFO" }}Info{{ else if eq .level_raw "DEBUG" }}Debug{{ else if .http_status }}Warning{{ else }}Info{{ end }}`
+      template = `{{ if eq .level_raw "EMERGENCY" }}critical{{ else if eq .level_raw "ALERT" }}critical{{ else if eq .level_raw "CRITICAL" }}critical{{ else if eq .level_raw "ERROR" }}error{{ else if eq .level_raw "WARNING" }}warning{{ else if eq .level_raw "INFO" }}info{{ else if eq .level_raw "DEBUG" }}debug{{ else if .http_status }}warning{{ else }}info{{ end }}`
     }
 
     stage.labels {
@@ -221,7 +224,7 @@ loki.process "docker" {
 
     stage.template {
       source   = "level"
-      template = `{{ $l := .level_raw | lower }}{{ if eq $l "error" }}Error{{ else if eq $l "warn" }}Warning{{ else if eq $l "info" }}Info{{ else if eq $l "debug" }}Debug{{ else if eq $l "fatal" }}Fatal{{ else }}{{ .level_raw }}{{ end }}`
+      template = `{{ $l := .level_raw | lower }}{{ if eq $l "error" }}error{{ else if eq $l "warn" }}warning{{ else if eq $l "info" }}info{{ else if eq $l "debug" }}debug{{ else if eq $l "fatal" }}critical{{ else }}info{{ end }}`
     }
 
     stage.labels {
@@ -246,10 +249,11 @@ loki.process "docker" {
       expression = `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z (?P<level_raw>TRC|DBG|INF|WRN|ERR|FTL) `
     }
 
-    // Map abbreviated levels to standard names Grafana recognises.
+    // Map abbreviated levels to standard names Grafana/VictoriaLogs recognises.
+    // FTL (fatal) → critical; TRC → trace.
     stage.template {
       source   = "level"
-      template = `{{ if eq .level_raw "WRN" }}Warning{{ else if eq .level_raw "ERR" }}Error{{ else if eq .level_raw "INF" }}Info{{ else if eq .level_raw "DBG" }}Debug{{ else if eq .level_raw "TRC" }}Trace{{ else if eq .level_raw "FTL" }}Fatal{{ else }}{{ .level_raw }}{{ end }}`
+      template = `{{ if eq .level_raw "WRN" }}warning{{ else if eq .level_raw "ERR" }}error{{ else if eq .level_raw "INF" }}info{{ else if eq .level_raw "DBG" }}debug{{ else if eq .level_raw "TRC" }}trace{{ else if eq .level_raw "FTL" }}critical{{ else }}info{{ end }}`
     }
 
     stage.labels {
@@ -294,16 +298,16 @@ loki.process "docker" {
       }
     }
 
-    // 4xx = blocked bots / auth failures — expected behaviour, treat as Info.
-    // Only 5xx server errors are Warning.
+    // 4xx = blocked bots / auth failures — expected behaviour, treat as info.
+    // Only 5xx server errors are warning.
     stage.static_labels {
-      values = { level = "Info" }
+      values = { level = "info" }
     }
 
     stage.match {
       selector = `{service="wordpress", status=~"5[0-9][0-9]"}`
       stage.static_labels {
-        values = { level = "Warning" }
+        values = { level = "warning" }
       }
     }
   }
@@ -323,7 +327,7 @@ loki.process "docker" {
 
     stage.template {
       source   = "level"
-      template = `{{ if eq .level_char "#" }}Warning{{ else if eq .level_char "-" }}Debug{{ else if eq .level_char "." }}Debug{{ else }}Info{{ end }}`
+      template = `{{ if eq .level_char "#" }}warning{{ else if eq .level_char "-" }}debug{{ else if eq .level_char "." }}debug{{ else }}info{{ end }}`
     }
 
     stage.labels {
@@ -335,19 +339,20 @@ loki.process "docker" {
   // MYSQL: extract level from bracketed token
   //
   // Format: 2026-03-22T05:20:57Z 0 [Warning] [MY-010068] [Server] msg
-  // Levels (already Title Case): Note, Warning, Error, System
+  // Native levels: Note, Warning, Error, System
+  // Mapping: Note/System → info, Warning → warning, Error → error
   // ----------------------------------------------------------
   stage.match {
     selector = `{service="mysql"}`
 
     stage.regex {
-      expression = `\[(?P<level>Note|Warning|Error|System)\]`
+      expression = `\[(?P<level_raw>Note|Warning|Error|System)\]`
     }
 
-    // Default to "Info" when no bracketed level token is found.
+    // Map MySQL native levels to standard; default info when no token found.
     stage.template {
       source   = "level"
-      template = `{{ if .level }}{{ .level }}{{ else }}System{{ end }}`
+      template = `{{ if eq .level_raw "Error" }}error{{ else if eq .level_raw "Warning" }}warning{{ else }}info{{ end }}`
     }
 
     stage.labels {
@@ -404,7 +409,7 @@ loki.process "mysql_slowlog" {
   stage.static_labels {
     values = {
       log_type = "slow_query",
-      level    = "Warning",
+      level    = "warning",
     }
   }
 

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -87,10 +87,11 @@ loki.process "docker" {
 
     stage.labels {
       values = {
-        method      = "method",
-        status      = "status",
-        remote_addr = "remote_addr",
-        uri         = "uri",
+        method       = "method",
+        status       = "status",
+        remote_addr  = "remote_addr",
+        uri          = "uri",
+        request_time = "request_time",
       }
     }
 

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -94,15 +94,16 @@ loki.process "docker" {
       }
     }
 
-    // Build a human-readable _msg so VictoriaLogs does not try to JSON-parse
-    // the log line and report "missing _msg field".
-    // Result: GET /api/role/1 200 0.447s
+    // Store a human-readable message in extracted["_msg"] WITHOUT calling
+    // stage.output here. Rewriting the log line inside this match would change
+    // it from "{...}" to "GET /uri 200 0.4s", causing the entry to satisfy the
+    // next selector ({service="nginx"} !~ "^\\{") and be reprocessed by the
+    // nginx error-log branch — which would overwrite any Warning set for 5xx.
+    // The final stage.template at the bottom of this pipeline uses _msg when
+    // set, so the output is still the human-readable string sent to VictoriaLogs.
     stage.template {
       source   = "_msg"
       template = `{{ .method }} {{ .uri }} {{ .status }} {{ .request_time }}s`
-    }
-    stage.output {
-      source = "_msg"
     }
 
     // Prometheus metrics exposed at Alloy's :12345/metrics endpoint.
@@ -355,11 +356,13 @@ loki.process "docker" {
     }
   }
 
-  // Capture the current log line into extracted["_entry"], then use it
-  // as _msg for VictoriaLogs. stage.output requires a non-empty source.
+  // Final output: use the pre-formatted message from extracted["_msg"] when
+  // set (nginx JSON access logs), otherwise fall back to the current log line.
+  // This avoids rewriting the log line inside individual match blocks, which
+  // would cause entries to be re-matched by subsequent selectors.
   stage.template {
     source   = "_entry"
-    template = "{{ .Entry }}"
+    template = `{{ if ._msg }}{{ ._msg }}{{ else }}{{ .Entry }}{{ end }}`
   }
   stage.output {
     source = "_entry"

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -80,6 +80,8 @@ loki.process "docker" {
         request_time           = "request_time",
         upstream_response_time = "upstream_response_time",
         remote_addr            = "remote_addr",
+        bytes_sent             = "bytes_sent",
+        http_user_agent        = "http_user_agent",
       }
     }
 
@@ -88,7 +90,19 @@ loki.process "docker" {
         method      = "method",
         status      = "status",
         remote_addr = "remote_addr",
+        uri         = "uri",
       }
+    }
+
+    // Build a human-readable _msg so VictoriaLogs does not try to JSON-parse
+    // the log line and report "missing _msg field".
+    // Result: GET /api/role/1 200 0.447s
+    stage.template {
+      source   = "_msg"
+      template = `{{ .method }} {{ .uri }} {{ .status }} {{ .request_time }}s`
+    }
+    stage.output {
+      source = "_msg"
     }
 
     // Prometheus metrics exposed at Alloy's :12345/metrics endpoint.
@@ -108,19 +122,17 @@ loki.process "docker" {
       }
     }
 
-    // Mark 4xx/5xx with level=error so Grafana colour-codes them.
-    stage.match {
-      selector = `{service="nginx", status=~"[45][0-9][0-9]"}`
-      stage.static_labels {
-        values = { level = "Error" }
-      }
+    // 4xx = client intent (auth challenge, redirect, not found) — still Info.
+    // Only 5xx server errors are Warning.
+    stage.static_labels {
+      values = { level = "Info" }
     }
 
-    // Drop 2xx/3xx — not useful for log search.
     stage.match {
-      selector            = `{service="nginx", status!~"[45][0-9][0-9]"}`
-      action              = "drop"
-      drop_counter_reason = "nginx_non_error_status"
+      selector = `{service="nginx", status=~"5[0-9][0-9]"}`
+      stage.static_labels {
+        values = { level = "Warning" }
+      }
     }
   }
 
@@ -135,61 +147,58 @@ loki.process "docker" {
 
     stage.decolorize {}
 
+    // nginx error log: 2026/03/22 04:12:31 [error] 1#1: message
     stage.regex {
       expression = `\[(?P<level_raw>debug|info|notice|warn|error|crit|alert|emerg)\]`
     }
 
+    // nginx / php-fpm text access log: IP - [time] "REQUEST" STATUS [bytes ...]
+    // Only capture 5xx; 4xx and below are treated as Info.
+    stage.regex {
+      expression = `" (?P<http_status>5\d\d)(?: |$)`
+    }
+
+    // Priority: nginx error level > HTTP 5xx > Info (default).
     stage.template {
       source   = "level"
-      template = `{{ if eq .level_raw "emerg" }}Emergency{{ else if eq .level_raw "alert" }}Alert{{ else if eq .level_raw "crit" }}Critical{{ else if eq .level_raw "error" }}Error{{ else if eq .level_raw "warn" }}Warning{{ else if eq .level_raw "notice" }}Notice{{ else if eq .level_raw "info" }}Info{{ else if eq .level_raw "debug" }}Debug{{ else }}{{ .level_raw }}{{ end }}`
+      template = `{{ if eq .level_raw "emerg" }}Emergency{{ else if eq .level_raw "alert" }}Alert{{ else if eq .level_raw "crit" }}Critical{{ else if eq .level_raw "error" }}Error{{ else if eq .level_raw "warn" }}Warning{{ else if eq .level_raw "notice" }}Notice{{ else if eq .level_raw "info" }}Info{{ else if eq .level_raw "debug" }}Debug{{ else if .http_status }}Warning{{ else }}Info{{ end }}`
     }
 
     stage.labels {
       values = { level = "level" }
-    }
-
-    // Drop debug and info — not actionable.
-    stage.match {
-      selector            = `{service="nginx"} !~ "\\[(warn|error|crit|alert|emerg)\\]"`
-      action              = "drop"
-      drop_counter_reason = "nginx_error_log_below_warn"
     }
   }
 
   // ----------------------------------------------------------
-  // LARAVEL (php / reverb containers): error logs + runner INFO
+  // LARAVEL (php / reverb / worker containers)
   //
-  // Laravel stderr channel outputs to Docker logs.
-  // Format: [YYYY-MM-DD HH:MM:SS] env.LEVEL: message
+  // Two log formats coexist in these containers:
+  //   1. Laravel structured:  [YYYY-MM-DD HH:MM:SS] env.LEVEL: message
+  //   2. PHP access log:      IP -  DATE "METHOD URI" STATUS
+  //
+  // Priority: Laravel level > HTTP 5xx > Info (default).
+  // 4xx access responses are treated as Info (client-side intent).
   // ----------------------------------------------------------
   stage.match {
-    selector = `{service=~"php|reverb"}`
+    selector = `{service=~"php|reverb|worker"}`
 
+    // Format 1: Laravel structured log level.
     stage.regex {
       expression = `\] \w+\.(?P<level_raw>DEBUG|INFO|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY):`
     }
 
+    // Format 2: PHP access log — only flag 5xx as Warning; 4xx and below → Info.
+    stage.regex {
+      expression = `" (?P<http_status>5\d\d)$`
+    }
+
     stage.template {
       source   = "level"
-      template = `{{ if eq .level_raw "EMERGENCY" }}Emergency{{ else if eq .level_raw "ALERT" }}Alert{{ else if eq .level_raw "CRITICAL" }}Critical{{ else if eq .level_raw "ERROR" }}Error{{ else if eq .level_raw "WARNING" }}Warning{{ else if eq .level_raw "INFO" }}Info{{ else if eq .level_raw "DEBUG" }}Debug{{ else }}{{ .level_raw }}{{ end }}`
+      template = `{{ if eq .level_raw "EMERGENCY" }}Emergency{{ else if eq .level_raw "ALERT" }}Alert{{ else if eq .level_raw "CRITICAL" }}Critical{{ else if eq .level_raw "ERROR" }}Error{{ else if eq .level_raw "WARNING" }}Warning{{ else if eq .level_raw "INFO" }}Info{{ else if eq .level_raw "DEBUG" }}Debug{{ else if .http_status }}Warning{{ else }}Info{{ end }}`
     }
 
     stage.labels {
       values = { level = "level" }
-    }
-
-    // Drop Debug — too noisy, not actionable.
-    stage.match {
-      selector            = `{service=~"php|reverb", level="Debug"}`
-      action              = "drop"
-      drop_counter_reason = "laravel_debug_filtered"
-    }
-
-    // Drop lines with no recognised Laravel log level (framework/boot noise).
-    stage.match {
-      selector            = `{service=~"php|reverb"} !~ "\\] \\w+\\.(DEBUG|INFO|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY):"`
-      action              = "drop"
-      drop_counter_reason = "laravel_no_level"
     }
   }
 
@@ -246,12 +255,79 @@ loki.process "docker" {
     stage.labels {
       values = { level = "level" }
     }
+  }
 
-    // Drop trace, debug, info — only warn and above for Traefik.
+  // ----------------------------------------------------------
+  // WORDPRESS: Apache combined log format (stdout)
+  //
+  // Format: remote_addr - - [time] "METHOD uri HTTP/x.x" status bytes "referer" "ua"
+  // Parses request fields, generates Prometheus metrics, marks
+  // 4xx/5xx as Error and 2xx/3xx as Info.
+  // ----------------------------------------------------------
+  stage.match {
+    selector = `{service="wordpress"}`
+
+    stage.regex {
+      expression = `^(?P<remote_addr>\S+) \S+ \S+ \[[^\]]+\] "(?P<method>\S+) (?P<uri>\S*) [^"]*" (?P<status>\d+) (?P<bytes_sent>\d+) "(?P<referer>[^"]*)" "(?P<user_agent>[^"]*)"`
+    }
+
+    stage.labels {
+      values = {
+        method      = "method",
+        status      = "status",
+        remote_addr = "remote_addr",
+      }
+    }
+
+    stage.metrics {
+      metric.histogram {
+        name        = "wordpress_request_duration_seconds"
+        description = "WordPress HTTP request duration in seconds (from bytes_sent proxy)"
+        source      = "bytes_sent"
+        buckets     = [256, 512, 1024, 4096, 16384, 65536, 262144, 1048576]
+      }
+      metric.counter {
+        name        = "wordpress_http_requests_total"
+        description = "Total WordPress HTTP requests by method and status"
+        match_all   = true
+        action      = "inc"
+      }
+    }
+
+    // 4xx = blocked bots / auth failures — expected behaviour, treat as Info.
+    // Only 5xx server errors are Warning.
+    stage.static_labels {
+      values = { level = "Info" }
+    }
+
     stage.match {
-      selector            = `{service="traefik", level=~"Trace|Debug|Info"}`
-      action              = "drop"
-      drop_counter_reason = "traefik_below_warn"
+      selector = `{service="wordpress", status=~"5[0-9][0-9]"}`
+      stage.static_labels {
+        values = { level = "Warning" }
+      }
+    }
+  }
+
+  // ----------------------------------------------------------
+  // REDIS: map single-character level markers
+  //
+  // Format: PID:ROLE DD Mon YYYY HH:MM:SS.mmm CHAR message
+  // Level chars:  . (debug)   - (verbose)   * (notice/info)   # (warning)
+  // ----------------------------------------------------------
+  stage.match {
+    selector = `{service="redis"}`
+
+    stage.regex {
+      expression = `\d+:[A-Z] \d+ \w+ \d+ \d+:\d+:\d+\.\d+ (?P<level_char>[.*#\-]) `
+    }
+
+    stage.template {
+      source   = "level"
+      template = `{{ if eq .level_char "#" }}Warning{{ else if eq .level_char "-" }}Debug{{ else if eq .level_char "." }}Debug{{ else }}Info{{ end }}`
+    }
+
+    stage.labels {
+      values = { level = "level" }
     }
   }
 
@@ -268,20 +344,25 @@ loki.process "docker" {
       expression = `\[(?P<level>Note|Warning|Error|System)\]`
     }
 
+    // Default to "Info" when no bracketed level token is found.
+    stage.template {
+      source   = "level"
+      template = `{{ if eq .level "" }}System{{ else }}{{ .level }}{{ end }}`
+    }
+
     stage.labels {
       values = { level = "level" }
     }
   }
 
-  // ----------------------------------------------------------
-  // ALL OTHER services (redis, …):
-  // keep only warning-and-above messages.
-  // nginx, php, reverb, node, traefik, mysql already handled above.
-  // ----------------------------------------------------------
-  stage.match {
-    selector            = `{service!~"nginx|php|reverb|node|traefik|mysql"} !~ "(?i)\\b(warn|warning|error|fatal|panic|critical|alert|emerg|emergency)\\b"`
-    action              = "drop"
-    drop_counter_reason = "non_warning_or_higher"
+  // Capture the current log line into extracted["_entry"], then use it
+  // as _msg for VictoriaLogs. stage.output requires a non-empty source.
+  stage.template {
+    source   = "_entry"
+    template = "{{ .Entry }}"
+  }
+  stage.output {
+    source = "_entry"
   }
 
   forward_to = [loki.write.victorialogs.receiver]
@@ -323,6 +404,15 @@ loki.process "mysql_slowlog" {
       log_type = "slow_query",
       level    = "Warning",
     }
+  }
+
+  // Capture the current log line as _msg for VictoriaLogs.
+  stage.template {
+    source   = "_entry"
+    template = "{{ .Entry }}"
+  }
+  stage.output {
+    source = "_entry"
   }
 
   forward_to = [loki.write.victorialogs.receiver]

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -87,11 +87,9 @@ loki.process "docker" {
 
     stage.labels {
       values = {
-        method       = "method",
-        status       = "status",
-        remote_addr  = "remote_addr",
-        uri          = "uri",
-        request_time = "request_time",
+        method      = "method",
+        status      = "status",
+        remote_addr = "remote_addr",
       }
     }
 
@@ -182,7 +180,7 @@ loki.process "docker" {
   // 4xx access responses are treated as Info (client-side intent).
   // ----------------------------------------------------------
   stage.match {
-    selector = `{service=~"php|reverb|worker"}`
+    selector = `{service=~"php|reverb|.*worker"}`
 
     // Format 1: Laravel structured log level.
     stage.regex {

--- a/observability/grafana/dashboards/container-logs.json
+++ b/observability/grafana/dashboards/container-logs.json
@@ -1,0 +1,264 @@
+{
+  "id": 102,
+  "type": "table",
+  "title": "日誌列表 nginx",
+  "gridPos": {
+    "x": 0,
+    "y": 31,
+    "h": 15,
+    "w": 24
+  },
+  "fieldConfig": {
+    "defaults": {
+      "custom": {
+        "align": "center",
+        "footer": {
+          "reducers": []
+        },
+        "cellOptions": {
+          "type": "json-view"
+        },
+        "inspect": false
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "transparent",
+            "value": null
+          }
+        ]
+      }
+    },
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "level"
+        },
+        "properties": [
+          {
+            "id": "custom.cellOptions",
+            "value": {
+              "mode": "basic",
+              "type": "color-background"
+            }
+          },
+          {
+            "id": "mappings",
+            "value": [
+              {
+                "options": {
+                  "Error": {
+                    "color": "red",
+                    "index": 0
+                  },
+                  "Warning": {
+                    "color": "yellow",
+                    "index": 2
+                  },
+                  "error": {
+                    "color": "red",
+                    "index": 1
+                  },
+                  "warning": {
+                    "color": "yellow",
+                    "index": 3
+                  }
+                },
+                "type": "value"
+              }
+            ]
+          },
+          {
+            "id": "custom.width",
+            "value": 73
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "request_time"
+        },
+        "properties": [
+          {
+            "id": "decimals",
+            "value": 0
+          },
+          {
+            "id": "unit",
+            "value": "s"
+          },
+          {
+            "id": "custom.cellOptions",
+            "value": { "type": "auto" }
+          },
+          {
+            "id": "custom.width",
+            "value": 330
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "uri"
+        },
+        "properties": [
+          {
+            "id": "custom.align",
+            "value": "left"
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "Line"
+        },
+        "properties": [
+          {
+            "id": "custom.align",
+            "value": "left"
+          },
+          {
+            "id": "custom.width",
+            "value": 813
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "Time"
+        },
+        "properties": [
+          {
+            "id": "custom.width",
+            "value": 195
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "service"
+        },
+        "properties": [
+          {
+            "id": "custom.width",
+            "value": 89
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "status"
+        },
+        "properties": [
+          {
+            "id": "custom.width",
+            "value": 78
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "method"
+        },
+        "properties": [
+          {
+            "id": "custom.width",
+            "value": 80
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "remote_addr"
+        },
+        "properties": [
+          {
+            "id": "custom.width",
+            "value": 108
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "service"
+        },
+        "properties": [
+          {
+            "id": "custom.cellOptions",
+            "value": {
+              "type": "pill"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "transformations": [
+    {
+      "id": "extractFields",
+      "options": {
+        "source": "labels"
+      }
+    },
+    {
+      "id": "organize",
+      "options": {
+        "includeByName": {
+          "Line": true,
+          "Time": true,
+          "level": true,
+          "method": true,
+          "remote_addr": true,
+          "request_time": true,
+          "service": true,
+          "status": true,
+          "uri": true
+        },
+        "indexByName": {
+          "Line": 3,
+          "Time": 0,
+          "level": 2,
+          "method": 7,
+          "remote_addr": 5,
+          "request_time": 4,
+          "service": 1,
+          "status": 6,
+          "uri": 8
+        }
+      }
+    }
+  ],
+  "pluginVersion": "12.4.0-21693836646",
+  "targets": [
+    {
+      "datasource": {
+        "type": "victoriametrics-logs-datasource",
+        "uid": "$datasource"
+      },
+      "editorMode": "code",
+      "expr": "compose_project: \"$compose_project\" service: \"nginx\" level: \"$level\"",
+      "queryType": "instant",
+      "refId": "A"
+    }
+  ],
+  "datasource": {
+    "type": "victoriametrics-logs-datasource",
+    "uid": "$datasource"
+  },
+  "options": {
+    "showHeader": true,
+    "cellHeight": "sm"
+  }
+}


### PR DESCRIPTION
## Summary

完整的 Docker 開發環境與可觀測性基礎設施：
- ✅ Alloy 統一 log 收集與 level 標準化（VictoriaLogs 相容）
- ✅ Nginx route 正規化：動態參數聚合為路由模板 (e.g., `/api/order/:id`)
- ✅ 完整文檔與環境變數說明

### 主要變更

#### 1. 可觀測性管道 (Observability Pipeline)
- 新增 observability/alloy/config.alloy：完整 Alloy 配置，支援 7+ 服務（nginx, php, reverb, node, traefik, redis, mysql）
- 統一 log level 格式：Grafana/VictoriaLogs 標準（debug/info/warning/error/critical）
- MySQL slow query log 多行收集 (stage.multiline)
- Prometheus metrics 生成：nginx request duration histogram
- 新增 Grafana dashboard: container-logs.json

#### 2. Nginx Route 正規化 (Route Label Extraction)
**Problem:** Nginx log 中每個不同 ID 都是獨立的請求，無法聚合觀測

**Solution:**
- nginx map $uri $route_label 依據 Laravel route:list 自動生成規則
- 將動態 ID（數字用 \d+，非數字用 [^/]+）替換為 :id / :code / :param
- Log format 新增 route 欄位輸出 $route_label
- Alloy 解析 route 欄位並設為 stream label

**效果：**
```
實際請求                    route (正規化)
/api/order/42            →  /api/order/:id
/api/stock/price/2330    →  /api/stock/price/:code
/api/simulation/result/v1 →  /api/simulation/result/:param
```

Prometheus histogram nginx_request_duration_seconds 自動帶有 route label，可按路由模板觀測 p95/p99 request time。

#### 4. 文檔 (Documentation)
- README.md：服務說明、環境變數設定、啟動與日誌查詢
- .env.example：新增 Alloy 相關環境變數

### 環境設定

新增至 .env：
```env
VLOGS_PUSH_URL=https://<victorialogs-domain>/insert/loki/api/v1/push
VLOGS_USERNAME=<basic-auth-username>
VLOGS_PASSWORD=<basic-auth-password>
LOG_HOSTNAME=local-docker-host
```

### 提交 (Commits)

| Commit | 描述 |
|--------|------|
| 2b92064 | feat(observability): 新增 nginx route 正規化，並在 Alloy 中提取 route label |
| 65957d3 | fix(alloy): address code review - reduce label cardinality and fix worker selector |
| 9d54c2e | feat(alloy): add request_time to nginx log labels |
| 24351f4 | fix(observability): 修正 MySQL level fallback 及 WordPress metrics 命名 |
| 5e4310c | fix(observability): 修正 nginx JSON log 被 error-log branch 重複處理的問題 |
| d0ad4c8 | feat(observability): 改善 Alloy log level 判定與新增服務支援 |
| fd1c5c1 | feat(observability): 新增 Alloy log 收集pipeline，統一 level 格式並支援 MySQL slow log |
| 3f105a2 | refactor(nginx): consolidate laravel api routing rules |
| 25ffebd | 升級 node 至 v22 並用 reverb 替換 laravel-echo-server |
| d1d91f3 | 升級 PHP 版本至 8.2，調整 local.ini 的 post_max_size，並將 start.sh 中的 queue:listen 指令改為 queue:work |
| 18a6431 | 新增 default-worker 服務，調整 start.sh 中的隊列監聽參數，並調整 nginx config |

## Test Plan

- [ ] 啟動全部服務：docker compose up -d
- [ ] 檢查各服務正常運行：docker compose ps
- [ ] 驗證 Alloy 成功連接 VictoriaLogs：docker logs alloy | grep "starting cluster node"
- [ ] 產生 Nginx log 流量：訪問 http://stock.local/api/order/1, /api/order/2 等
- [ ] 驗證 Alloy 正確解析 route label
  - 使用 VictoriaLogs 查詢：{service="nginx", route="/api/order/:id"} 應該聚合多筆請求
  - 檢查 route 欄位正確被提取
- [ ] 驗證 Prometheus metrics：Alloy :12345/metrics 應該有 nginx_request_duration_seconds with route label
- [ ] 檢查 Grafana dashboard：container-logs 應該顯示 route 分組
- [ ] 確認 MySQL slow query log 正確被收集（if applicable）
- [ ] 驗證各服務 log level 統一為小寫標準格式

🤖 Generated with [Claude Code](https://claude.com/claude-code)