### PR TITLE
perf: optimize PHP-FPM and Nginx configurations for high concurrency

### DIFF
--- a/nginx/conf.d/site.conf
+++ b/nginx/conf.d/site.conf
@@ -1,3 +1,9 @@
+upstream php-fpm {
+    server php:9000;
+    keepalive 32;
+    keepalive_timeout 60s;
+}
+
 # Route label normalization — generated from `php artisan route:list`.
 # Uses \d+ for numeric model keys (safe: avoids matching static sub-paths like /create).
 # Uses [^/]+ for non-numeric params (version, stock code, token, hash).
@@ -144,7 +150,8 @@ server {
     # Laravel entrypoint for backend-routed requests
     location @laravel_app {
         include fastcgi_params;
-        fastcgi_pass php:9000;
+        fastcgi_pass php-fpm;
+        fastcgi_keep_conn on;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root/index.php;
         fastcgi_param REQUEST_URI $uri$is_args$args;

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -19,8 +19,11 @@ RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 # Install PHP extensions
 RUN docker-php-source extract && \
-    docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip && \
+    docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip opcache && \
     docker-php-source delete
+
+# Copy custom FPM configuration
+COPY www.conf /usr/local/etc/php-fpm.d/zzz-custom.conf
 
 USER www-data
 

--- a/php/local.ini
+++ b/php/local.ini
@@ -1,2 +1,14 @@
 upload_max_filesize=40M
 post_max_size=512M
+memory_limit=512M
+
+[opcache]
+opcache.enable=1
+opcache.enable_cli=1
+opcache.memory_consumption=256
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=10000
+opcache.validate_timestamps=1
+opcache.revalidate_freq=0
+opcache.jit_buffer_size=100M
+opcache.jit=tracing

--- a/php/www.conf
+++ b/php/www.conf
@@ -1,0 +1,7 @@
+[www]
+pm = dynamic
+pm.max_children = 100
+pm.start_servers = 10
+pm.min_spare_servers = 5
+pm.max_spare_servers = 20
+pm.max_requests = 1000


### PR DESCRIPTION
# Laravel + Nginx + PHP-FPM 壓力測試與效能優化報告

這份文件記錄了在 Mac M4 pro 環境下，透過調整 Docker 容器中的 Nginx 與 PHP-FPM 設定，將 Laravel API 的吞吐量 (RPS) 提升 4.5 倍，並將 95% 請求響應時間 (p95) 從 4.37 秒大幅縮短至 37 毫秒的完整過程。

## 階段一：基準測試 (Baseline)

在預設的 PHP-FPM 配置 (預設 `pm.max_children` 通常很小，如 5) 且未開啟任何快取與連線重用的情況下，面對 100 個併發請求，系統出現嚴重的排隊阻塞 (Queueing)。

### 測試結果 (未優化)
- **吞吐量 (RPS)**: 16.95 req/s
- **p95 響應時間**: 4.37s
- **最大響應時間 (max)**: 8.14s

```text
  █ THRESHOLDS 

    http_req_duration
    ✗ 'p(95)<500' p(95)=4.37s


  █ TOTAL RESULTS 

    checks_total.......: 859     16.956267/s
    checks_succeeded...: 100.00% 859 out of 859
    checks_failed......: 0.00%   0 out of 859

    ✓ is status 200

    HTTP
    http_req_duration..............: avg=3.74s min=273.13ms med=4.04s max=4.44s p(90)=4.34s p(95)=4.37s
      { expected_response:true }...: avg=3.74s min=273.13ms med=4.04s max=4.44s p(90)=4.34s p(95)=4.37s
    http_req_failed................: 0.00%  0 out of 859
    http_reqs......................: 859    16.956267/s

    EXECUTION
    iteration_duration.............: avg=4.89s min=1.33s    med=5.06s max=8.14s p(90)=5.36s p(95)=5.39s
    iterations.....................: 859    16.956267/s
    vus............................: 16     min=10       max=100
    vus_max........................: 100    min=100      max=100

    NETWORK
    data_received..................: 79 MB  1.6 MB/s
    data_sent......................: 333 kB 6.6 kB/s
```

---

## 階段二：擴充 FPM Worker 池與啟用 Nginx Keepalive

### 調整項目
1. **PHP-FPM (`php/www.conf`)**:
   - `pm.max_children = 100`: 設定 PHP-FPM 最多可以產生 100 個子行程 (Worker)。這解決了 100 個併發請求進來時，因為 Worker 數量不足導致 90 幾個請求都在排隊的問題。在 M1 晶片且記憶體充足的情況下，100 是一個安全且有餘裕的數字。
2. **Nginx (`nginx/conf.d/site.conf`)**:
   - `upstream` 區塊與 `keepalive 32;`: 讓 Nginx 與 PHP-FPM 之間保持 32 個長連線 (Keepalive)。這消除了每次 Nginx 轉發請求給 PHP 時都要重新建立 TCP 連線的開銷。
   - 這裡的關鍵是 `keepalive` 數量必須**嚴格小於** FPM 的 `pm.max_children`，避免所有的 FPM Worker 都被長連線「霸佔」導致假死。

### 測試結果 (調整 FPM 與 Nginx)
吞吐量翻倍，p95 延遲下降至 1.48 秒，排隊現象顯著改善，但距離 500ms 的目標仍有差距。這表示目前的瓶頸轉移到了 PHP 程式本身的執行時間。

- **吞吐量 (RPS)**: 36.06 req/s
- **p95 響應時間**: 1.48s
- **最大響應時間 (max)**: 2.34s

```text
  █ THRESHOLDS 

    http_req_duration
    ✗ 'p(95)<500' p(95)=1.48s


  █ TOTAL RESULTS 

    checks_total.......: 1835    36.065883/s
    checks_succeeded...: 100.00% 1835 out of 1835
    checks_failed......: 0.00%   0 out of 1835

    ✓ is status 200

    HTTP
    http_req_duration..............: avg=1.15s min=108.47ms med=1.2s  max=2.34s p(90)=1.42s p(95)=1.48s
      { expected_response:true }...: avg=1.15s min=108.47ms med=1.2s  max=2.34s p(90)=1.42s p(95)=1.48s
    http_req_failed................: 0.00%  0 out of 1835
    http_reqs......................: 1835   36.065883/s

    EXECUTION
    iteration_duration.............: avg=2.22s min=1.11s    med=2.21s max=7.77s p(90)=2.43s p(95)=2.5s 
    iterations.....................: 1835   36.065883/s
    vus............................: 5      min=5         max=100
    vus_max........................: 100    min=100       max=100

    NETWORK
    data_received..................: 168 MB 3.3 MB/s
    data_sent......................: 493 kB 9.7 kB/s
```

---

## 階段三：啟用 OPcache, JIT 與 Laravel Optimize

要進一步降低單一請求的處理時間，必須減少 PHP 每次載入、解析與編譯腳本的時間，這對於像 Laravel 這樣載入大量檔案的框架尤為重要。

### 調整項目
1. **PHP OPcache (`php/local.ini`)**:
   - `opcache.enable=1`: 啟用 OPcache。它會將編譯好的 PHP Opcode 快取在共享記憶體中，省去每次讀取磁碟和編譯的 I/O 時間。
   - `opcache.jit=tracing`: 啟用 PHP 8 的 JIT (Just-In-Time) 編譯器。Tracing 模式會找出程式中最常執行的「熱點」路徑，將其直接編譯成 CPU 機器碼，大幅提升運算密集型任務的效能。
2. **Laravel 框架優化**:
   - 執行 `php artisan optimize`: 將路由 (Routes) 與設定檔 (Config) 快取成單一檔案，避免 Laravel 每次啟動時都要掃描所有路由和設定檔。

### 測試結果 (終速極限)
效能產生了質的飛躍。吞吐量再次翻倍，p95 響應時間暴跌至 37.86ms，徹底解決了效能瓶頸，遠遠低於 500ms 的閾值。

- **吞吐量 (RPS)**: 76.11 req/s
- **p95 響應時間**: 37.86ms
- **最大響應時間 (max)**: 484.93ms

```text
  █ THRESHOLDS 

    http_req_duration
    ✓ 'p(95)<500' p(95)=37.86ms


  █ TOTAL RESULTS 

    checks_total.......: 3831    76.115352/s
    checks_succeeded...: 100.00% 3831 out of 3831
    checks_failed......: 0.00%   0 out of 3831

    ✓ is status 200

    HTTP
    http_req_duration..............: avg=25.31ms min=9.75ms med=17.09ms max=484.93ms p(90)=32.34ms p(95)=37.86ms
      { expected_response:true }...: avg=25.31ms min=9.75ms med=17.09ms max=484.93ms p(90)=32.34ms p(95)=37.86ms
    http_req_failed................: 0.00%  0 out of 3831
    http_reqs......................: 3831   76.115352/s

    EXECUTION
    iteration_duration.............: avg=1.05s   min=1.01s  med=1.01s   max=6.48s    p(90)=1.03s   p(95)=1.03s  
    iterations.....................: 3831   76.115352/s
    vus............................: 8      min=8         max=100
    vus_max........................: 100    min=100       max=100

    NETWORK
    data_received..................: 351 MB 7.0 MB/s
    data_sent......................: 855 kB 17 kB/s
```

## 總結

透過上述三個階段的優化，我們建立了處理高併發 PHP/Laravel 應用的黃金鐵三角：
1. **足夠的 Worker 池 (`pm.max_children`)**: 防止請求排隊。
2. **長連線重用 (`fastcgi_keep_conn`)**: 減少 Nginx 與 FPM 溝通成本。
3. **消除重複編譯 (`OPcache + JIT + Laravel Optimize`)**: 將 PHP 腳本解析與框架初始化的開銷降至最低。

| 階段 | 吞吐量 (RPS) | p95 響應時間 | 解決的主要瓶頸 |
| :--- | :--- | :--- | :--- |
| 1. 基準測試 | 16.95 | 4.37s | (無) |
| 2. FPM & Keepalive | 36.06 | 1.48s | 消除 TCP 握手開銷與 FPM Worker 阻塞 |
| 3. OPcache & JIT | **76.11** | **37.86ms** | 消除 PHP 腳本讀取、編譯與 Laravel 初始化開銷 |
