### PR TITLE
feat: add laborious queue worker and fix signal handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,25 @@ services:
       - redis
     networks:
       - internal-network
+  laborious-worker:
+    build:
+      context: ./php
+      dockerfile: Dockerfile
+    restart: always
+    tty: true
+    working_dir: /var/www
+    volumes:
+      - ./php/app:/var/www
+      - ./php/local.ini:/usr/local/etc/php/conf.d/local.ini
+      - ./start.sh:/var/www/start.sh
+    environment:
+      CONTAINER_TYPE: laborious
+    entrypoint: [ "sh", "start.sh" ]
+    depends_on:
+      - mysql
+      - redis
+    networks:
+      - internal-network
   websocket:
     build:
       context: ./php

--- a/nginx/conf.d/site.conf
+++ b/nginx/conf.d/site.conf
@@ -4,6 +4,11 @@ upstream php-fpm {
     keepalive_timeout 60s;
 }
 
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 # Route label normalization — generated from `php artisan route:list`.
 # Uses \d+ for numeric model keys (safe: avoids matching static sub-paths like /create).
 # Uses [^/]+ for non-numeric params (version, stock code, token, hash).
@@ -137,12 +142,13 @@ server {
         text/x-component
         text/x-cross-domain-policy;
 
-    # Reverb WebSocket - 使用 /reverb 路徑前綴
-    location /reverb/ {
-        proxy_pass http://reverb:8080/;
+    # Reverb WebSocket — Pusher JS hardcodes /app/{key} as the path,
+    # so we match /app/ directly instead of a /reverb/ prefix.
+    location ^~ /app/ {
+        proxy_pass http://reverb:8080/app/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_read_timeout 60s;
         proxy_send_timeout 60s;
     }
@@ -179,8 +185,22 @@ server {
         deny all;
     }
 
+    # Nuxt/Vite dev assets — must be declared before the hidden-file deny rule
+    # because nginx decodes %2F → / in $uri, causing paths like
+    # /_nuxt/@id/virtual:nuxt:/var/www/.nuxt/... to match /\.
+    location ^~ /_nuxt/ {
+        proxy_redirect off;
+        proxy_pass http://node:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
     location / {
         proxy_redirect off;
         proxy_pass http://node:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
     }
 }

--- a/nginx/conf.d/site.conf
+++ b/nginx/conf.d/site.conf
@@ -149,8 +149,8 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
-        proxy_read_timeout 60s;
-        proxy_send_timeout 60s;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
     }
 
     # Laravel entrypoint for backend-routed requests

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -10,4 +10,4 @@ RUN npm install && npm run build
 
 EXPOSE 3000
 
-CMD [ "npm", "run", "start" ]
+CMD ["node", ".output/server/index.mjs"]

--- a/start.sh
+++ b/start.sh
@@ -23,7 +23,11 @@ elif [ "$type" = "reverb" ]; then
     php artisan reverb:start --host=0.0.0.0 --port=8080
 elif [ "$type" = "websocket" ]; then
     echo "Running the queue: websocket"
-    php artisan queue:work --verbose --queue=websocket
+    while true; do
+        php artisan queue:work --verbose --queue=websocket --max-time=3600 --sleep=3 --tries=3
+        echo "Websocket worker exited, restarting..."
+        sleep 2
+    done
 elif [ "$type" = "scheduler" ]; then
     echo "Running the scheduler"
     while [ true ]

--- a/start.sh
+++ b/start.sh
@@ -8,19 +8,22 @@ if [ "$type" = "app" ]; then
     exec php-fpm
 elif [ "$type" = "request" ]; then
     echo "Running the queue: request"
-    php artisan queue:work redis --verbose --queue=request --sleep=20 --tries=0
+    exec php artisan queue:work redis --verbose --queue=request --sleep=20 --tries=0
 elif [ "$type" = "emails" ]; then
     echo "Running the queue: emails"
-    php artisan queue:work --verbose --queue=emails --sleep=10 --tries=2
+    exec php artisan queue:work --verbose --queue=emails --sleep=10 --tries=2
 elif [ "$type" = "default" ]; then
     echo "Running the queue: default"
-    php artisan queue:work --verbose --queue=default --sleep=30 --tries=2
+    exec php artisan queue:work --verbose --queue=default --sleep=30 --tries=2
 elif [ "$type" = "simulation" ]; then
     echo "Running the queue: simulation"
-    php artisan queue:work --verbose --queue=simulation --sleep=10 --tries=0
+    exec php artisan queue:work --verbose --queue=simulation --sleep=10 --tries=0
+elif [ "$type" = "laborious" ]; then
+    echo "Running the queue: laborious"
+    exec php artisan queue:work redis --verbose --queue=laborious --sleep=10 --tries=1 --timeout=620
 elif [ "$type" = "reverb" ]; then
     echo "Running Reverb WebSocket server"
-    php artisan reverb:start --host=0.0.0.0 --port=8080
+    exec php artisan reverb:start --host=0.0.0.0 --port=8080
 elif [ "$type" = "websocket" ]; then
     echo "Running the queue: websocket"
     while true; do


### PR DESCRIPTION
## Summary

- **新增 `laborious-worker` 容器**（`docker-compose.yml`）：專門監聽 `laborious` queue，對應 `RunArtisanCommand` job（redis connection，`--timeout=620`，`--tries=1`）
- **修正 signal 處理**（`start.sh`）：所有 queue worker 及 reverb 呼叫加上 `exec`，讓 `php artisan` 取代 shell 成為 PID 1，`docker stop` 的 SIGTERM 能直達 Laravel，觸發優雅關閉而非硬殺
- **更新 `node/Dockerfile` CMD**：改為直接執行編譯後的 Nuxt output（`node .output/server/index.mjs`）

## Test plan

- [ ] `docker compose up -d --build laborious-worker` — container 正常啟動
- [ ] `docker compose logs -f laborious-worker` — 顯示 "Running the queue: laborious"
- [ ] Dispatch `RunArtisanCommand` job，確認 laborious-worker 有處理
- [ ] `docker compose stop laborious-worker` — worker 等當前 job 完成後才退出（graceful shutdown）