### PR TITLE
fix: simulation worker 改用 database-slow 連線並限制重試次數

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -17,7 +17,9 @@ elif [ "$type" = "default" ]; then
     exec php artisan queue:work --verbose --queue=default --sleep=30 --tries=2
 elif [ "$type" = "simulation" ]; then
     echo "Running the queue: simulation"
-    exec php artisan queue:work --verbose --queue=simulation --sleep=10 --tries=0
+    # database-slow 連線 retry_after=3700 > timeout=3600，避免長時間回測 job 被誤判卡住而重複派發
+    # tries=0(無限重試) 會讓真失敗的 job 永不進 failed、batch 永不收斂，改為 2
+    exec php artisan queue:work database-slow --verbose --queue=simulation --sleep=10 --tries=2 --timeout=3600
 elif [ "$type" = "laborious" ]; then
     echo "Running the queue: laborious"
     exec php artisan queue:work redis --verbose --queue=laborious --sleep=10 --tries=1 --timeout=620

--- a/start.sh
+++ b/start.sh
@@ -17,9 +17,10 @@ elif [ "$type" = "default" ]; then
     exec php artisan queue:work --verbose --queue=default --sleep=30 --tries=2
 elif [ "$type" = "simulation" ]; then
     echo "Running the queue: simulation"
-    # database-slow 連線 retry_after=3700 > timeout=3600，避免長時間回測 job 被誤判卡住而重複派發
+    # queue:listen 每個 job 用全新 process，跑完即釋放，避免長時間回測 job 的記憶體污染
+    # retry_after=3700 > timeout=3600（config/queue.php database 連線），避免執行中被誤判卡住而重複派發
     # tries=0(無限重試) 會讓真失敗的 job 永不進 failed、batch 永不收斂，改為 2
-    exec php artisan queue:work database-slow --verbose --queue=simulation --sleep=10 --tries=2 --timeout=3600
+    exec php artisan queue:listen --verbose --queue=simulation --sleep=10 --tries=2 --timeout=3600
 elif [ "$type" = "laborious" ]; then
     echo "Running the queue: laborious"
     exec php artisan queue:work redis --verbose --queue=laborious --sleep=10 --tries=1 --timeout=620


### PR DESCRIPTION
搭配 jba1989/laravel-stock#325（issue laravel-stock#324）：`retry_after(90s)` < job timeout 導致全市場回測 job 被 worker 重複派發、SimulationDetail 超額。

## 變更

simulation worker 啟動命令：

```diff
-exec php artisan queue:work --verbose --queue=simulation --sleep=10 --tries=0
+exec php artisan queue:listen --verbose --queue=simulation --sleep=10 --tries=2 --timeout=3600
```

- **`queue:work` → `queue:listen`**：每個 job 以全新 process 執行、跑完即釋放，長時間回測 job（單輪 ~17 分鐘）不再累積記憶體污染；framework bootstrap 開銷對此類 job 可忽略
- **`--tries=0` → `--tries=2`**：無限重試會讓真失敗的 job 永不進 failed、batch 永不收斂為 error
- **`--timeout=3600`**：與 laravel-stock#325 的 `retry_after=3700` 搭配（retry_after > timeout），worker 不再誤判執行中的 job 卡住而重複派發

## 部署

retry_after 定義在 laravel-stock 的 `config/queue.php` database 連線（#325），worker 沿用預設連線、無硬性部署順序，但建議與 #325 一起部署使修復完整生效，之後重建 simulation worker container。